### PR TITLE
docs: mention Arch Linux AUR package in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@
 
 ### Installation
 
+**Arch Linux (AUR)**
+```bash
+yay -S mcp-linker-bin
+```
+
 **macOS (Homebrew)**
 ```bash
 brew tap milisp/mcp-linker


### PR DESCRIPTION
## Summary
- add an Arch Linux (AUR) install option to the README installation section
- mention the published `mcp-linker-bin` package with a simple `yay -S` example
- keep the change README-only and minimal for easy review

## Testing
- not run (documentation-only change)

## Notes
- this PR is intended to help the README reflect that an AUR package is now available for Arch Linux users


Also see: https://aur.archlinux.org/packages/mcp-linker-bin
