### PR TITLE
Add optional Parallel Search MCP preset

### DIFF
--- a/src/components/claude-code/PreConfiguredServersDialog.tsx
+++ b/src/components/claude-code/PreConfiguredServersDialog.tsx
@@ -34,6 +34,13 @@ const MCP_SERVERS: MCPServer[] = [
     type: "http",
     url: "https://mcp.socket.dev/"
   },
+  {
+    name: "parallel-search",
+    description: "Opt in by clicking Add. User-provided search objectives, search queries, and requested URLs are sent to Parallel.",
+    category: "Development & Testing",
+    type: "http",
+    url: "https://search.parallel.ai/mcp"
+  },
   
   // Project Management & Documentation
   {


### PR DESCRIPTION
## Why

Adds an optional hosted web search and URL-fetching MCP server to the existing Claude Code preset catalog. The hosted endpoint does not require an account or API key.

## Changes

- Add Parallel Search as an HTTP preset using the existing MCP server flow.
- Require users to explicitly opt in by clicking **Add**; no provider, configured server, credential, or default is replaced or changed.
- Disclose that user-provided search objectives, search queries, and requested URLs are sent to Parallel when its tools are used.

## Validation

- `git diff --check`: passed.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.